### PR TITLE
fix hard-coded namespace in chains-controller dep

### DIFF
--- a/charts/tekton-chains/templates/Deployment-tekton-chains-controller.yml
+++ b/charts/tekton-chains/templates/Deployment-tekton-chains-controller.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tekton-chains-controller
-  namespace: tekton-chains
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: tekton-pipelines
     app.kubernetes.io/component: chains


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR fixes the hardcoded space in the controller deployment that prevents deployment in a namespace other than tekton-chains. The rest of the helm chart gracefully handles this, so I am making an assumption that this is a defect and not an intentional decision.
