### PR TITLE
fix: edit broken url in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Charts are available in the following formats:
 The following command can be used to add the chart repository:
 
 ```shell
-helm repo add tekton https://chainguard.github.io/tekton-helm-charts
+helm repo add tekton https://chainguard-dev.github.io/tekton-helm-charts
 helm repo update
 ```
 


### PR DESCRIPTION
The URL for the helm repository should be `https://chainguard-dev.github.io/tekton-helm-charts`